### PR TITLE
no date in cluster name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,7 @@ else
 fi
 
 echo Starting Elasticsearch to run in the background.  
-bin/elasticsearch -d --cluster.name=es_demo.`date +%s` --network.host=localhost
+bin/elasticsearch -d --cluster.name=es_demo --network.host=localhost
 
 cd ../$LOGSTASH_PATH
 echo loading nfl data using logstash


### PR DESCRIPTION
No need to add timestamp to cluster name - makes it harder to restart cluster later with existing data.
